### PR TITLE
Fix compiling using make

### DIFF
--- a/gamed/include/Stats.h
+++ b/gamed/include/Stats.h
@@ -4,6 +4,8 @@
 #include <map>
 #include <set>
 #include <algorithm>
+#include <cmath>
+#include <vector>
 
 #include "stdafx.h"
 #include "common.h"


### PR DESCRIPTION
Using

```
mkdir build
cd build
cmake ..
make
```

on *NIX systems will now compile without any complaints.
