### PR TITLE
Fixed purple respawn, added minion target prioritization, fixed turret target prioritization (mainly bug fixes)

### DIFF
--- a/gamed/include/Game.h
+++ b/gamed/include/Game.h
@@ -92,7 +92,7 @@ class Game
       void notifyShowProjectile(Projectile* p);
       void notifyNpcDie(Unit* die, Unit* killer);
       void notifyAutoAttackMelee(Unit* attacker, Unit* target, uint32 futureProjNetId, bool isCritical);
-      void notifyAddBuff(Unit* u, std::string buffName);
+      void notifyAddBuff(Unit* u, Unit* source, std::string buffName);
       void notifyRemoveBuff(Unit* u, std::string buffName);
       void notifyAddGold(Champion* c, Unit* died, float gold);
       void notifyStopAutoAttack(Unit* attacker);

--- a/gamed/include/Packets.h
+++ b/gamed/include/Packets.h
@@ -674,13 +674,13 @@ typedef struct _EmotionResponse {
 
 class AddBuff : public Packet {
 public:
-   AddBuff(Unit* u, int stacks, std::string name) : Packet(PKT_S2C_AddBuff) {
+   AddBuff(Unit* u, Unit* source, int stacks, std::string name) : Packet(PKT_S2C_AddBuff) {
       buffer << u->getNetId();//target
       
       buffer << (uint8) 0x05; //maybe type?
       buffer << (uint8) 0x02;
       buffer << (uint8) 0x01; // stacks
-      buffer << (uint8) 0x00;
+      buffer << (uint8) 0x00; // bool value
       buffer << RAFFile::getHash(name);
       buffer << (uint8) 0xde;
       buffer << (uint8) 0x88;
@@ -695,7 +695,11 @@ public:
       buffer << (uint8) 0xc3;
       buffer << (uint8) 0x46;
      
-      buffer << u->getNetId();//source?
+      if (source != 0) {
+         buffer << source->getNetId(); //source
+      } else {
+         buffer << (uint32)0;
+      }
    }
 };
 
@@ -880,7 +884,7 @@ public:
 class ChampionRespawn : public BasePacket {
 public:
    ChampionRespawn(Champion* c) : BasePacket(PKT_S2C_ChampionRespawn, c->getNetId()) {
-      buffer << c->getX() << 230.f << c->getY();
+      buffer << c->getX() << c->getY() << 230.f;
    } 
 };
 

--- a/gamed/include/Turret.h
+++ b/gamed/include/Turret.h
@@ -6,7 +6,6 @@
 class Turret : public Unit {
 private:
    std::string name;
-   unsigned int classifyTarget(Unit* u);
 
 public:
    Turret(Map* map, uint32 id, const std::string& name, float x = 0, float y = 0, float hp = 0, float ad = 0, int side = 0);

--- a/gamed/include/Unit.h
+++ b/gamed/include/Unit.h
@@ -96,6 +96,7 @@ public:
    virtual void refreshWaypoints();
    bool isMelee() const { return melee; }
    void setMelee(bool melee) { this->melee = melee; }
+   unsigned int classifyTarget(Unit* target);
 };
 
 #endif

--- a/gamed/include/common.h
+++ b/gamed/include/common.h
@@ -55,6 +55,7 @@ enum PacketCmd : uint8
    PKT_S2C_AttentionPing = 0x40,
 
    PKT_S2C_Emotion = 0x42,
+   PKT_C2S_AutoAttackOption = 0x47,
    PKT_C2S_Emotion = 0x48,
    PKT_S2C_HeroSpawn = 0x4C,
    PKT_S2C_Announce = 0x4D,

--- a/gamed/src/Buff.cpp
+++ b/gamed/src/Buff.cpp
@@ -48,7 +48,7 @@ Buff::Buff(std::string buffName, float dur, BuffType type, Unit* u, Unit* uu)  :
    }
    
    
-      attachedTo->getMap()->getGame()->notifyAddBuff(attachedTo, name);
+      attachedTo->getMap()->getGame()->notifyAddBuff(attachedTo, attacker, name);
    }
 }
 

--- a/gamed/src/Champion.cpp
+++ b/gamed/src/Champion.cpp
@@ -206,7 +206,7 @@ std::pair<float, float> Champion::getRespawnPosition() {
       }
 
    }
-   printf("team: %s /n", playerTeam.c_str());
+   printf("team: %s\n", playerTeam.c_str());
    printf("players before %i \n", playersBefore);
    //printf("player position in spawn list: %s", to_string(spawnNumber).c_str());
    LuaScript mapScript(false);
@@ -226,9 +226,9 @@ std::pair<float, float> Champion::getRespawnPosition() {
    catch (sol::error e) {
       printf("Error loading champion for \n%s\n", e.what());
    }
-   printf("team sizse: %i ", teamSize);
+   printf("team size: %i\n", teamSize);
    teamSizeSpawners = teamSpawners.get<sol::table>(to_string(teamSize));
-   printf("%f", teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "X"));
+   printf("%f\n", teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "X"));
    return std::make_pair(teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "X"), teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "Y"));
 }
 void Champion::die(Unit* killer) {

--- a/gamed/src/Handlers.cpp
+++ b/gamed/src/Handlers.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Packets.h"
 #include "ItemManager.h"
 #include "ChatBox.h"
+#include "LuaScript.h"
 
 #include <vector>
 #include <string>
@@ -67,17 +68,17 @@ bool Game::handleGameNumber(ENetPeer *peer, ENetPacket *packet) {
 }
 
 bool Game::handleSynch(ENetPeer *peer, ENetPacket *packet) {
-	SynchVersion *version = reinterpret_cast<SynchVersion *>(packet->data);
-	//Logging->writeLine("Client version: %s\n", version->version);
-	//Gets the map from the lua configurtation file.
-	LuaScript script(false);
-	script.loadScript("../../lua/config.lua");
-	sol::table config = script.getTable("game");
-	int mapId = config.get<int>("map");
-	printf("Current map: %i", mapId);
-	SynchVersionAns answer(players, "Version 4.13.0.262 [PUBLIC]", "CLASSIC", (uint32)mapId);
-    printPacket(reinterpret_cast<uint8 *>(&answer), sizeof(answer));
-    return sendPacket(peer, answer, 3);
+   SynchVersion *version = reinterpret_cast<SynchVersion *>(packet->data);
+   //Logging->writeLine("Client version: %s\n", version->version);
+   //Gets the map from the lua configuration file.
+   LuaScript script(false);
+   script.loadScript("../../lua/config.lua");
+   sol::table config = script.getTable("game");
+   int mapId = config.get<int>("map");
+   printf("Current map: %i\n", mapId);
+   SynchVersionAns answer(players, "Version 4.13.0.262 [PUBLIC]", "CLASSIC", (uint32)mapId);
+   printPacket(reinterpret_cast<uint8 *>(&answer), sizeof(answer));
+   return sendPacket(peer, answer, 3);
 }
 
 bool Game::handleMap(ENetPeer *peer, ENetPacket *packet) {

--- a/gamed/src/Notifiers.cpp
+++ b/gamed/src/Notifiers.cpp
@@ -22,8 +22,8 @@ void Game::notifyUpdatedStats(Unit* u) {
    broadcastPacket(us, CHL_LOW_PRIORITY, 2);
 }
 
-void Game::notifyAddBuff(Unit* u, std::string buffName) {
-   AddBuff add(u, 1, buffName);
+void Game::notifyAddBuff(Unit* u, Unit* source, std::string buffName) {
+   AddBuff add(u, source, 1, buffName);
    broadcastPacket(add, CHL_S2C);
 }
 

--- a/gamed/src/Turret.cpp
+++ b/gamed/src/Turret.cpp
@@ -20,7 +20,7 @@ Turret::Turret(Map* map, uint32 id, const std::string& name, float x, float y, f
 void Turret::update(int64 diff)
 {
    // No target : try to find a new one
-   if(!isAttacking && !unitTarget) {
+   if(!isAttacking) {
       const std::map<uint32, Object*>& objects = map->getObjects();
       Unit* nextTarget = 0;
       unsigned int nextTargetPriority = 10;
@@ -30,10 +30,28 @@ void Turret::update(int64 diff)
          if(!u || u->isDead() || u->getSide() == getSide() || distanceWith(u) > TURRET_RANGE) {
             continue;
          }
-         auto priority = classifyTarget(u);
-         if (priority < nextTargetPriority) {
-            nextTarget = u;
-            nextTargetPriority = priority;
+         
+         if (!unitTarget) {
+            auto priority = classifyTarget(u);
+            if (priority < nextTargetPriority) {
+               nextTarget = u;
+               nextTargetPriority = priority;
+            }
+         } else {
+            Champion* currentTarget = dynamic_cast<Champion*>(unitTarget);
+            
+            // Is the current target a champion? If it isn't, don't do anything
+            if (!currentTarget) {
+               // Find the next champion in range targeting an enemy champion who is also in range
+               Champion* c = dynamic_cast<Champion*>(u);
+               if (c && c->getUnitTarget() != 0) {
+                  Champion* target = dynamic_cast<Champion*>(c->getUnitTarget());
+                  if (target && c->distanceWith(target) <= c->getStats().getRange() && distanceWith(target) <= TURRET_RANGE) {
+                     nextTarget = c; // No priority required
+                     break;
+                  }
+               }
+            }
          }
       }
       if (nextTarget) {
@@ -46,30 +64,4 @@ void Turret::update(int64 diff)
    }
 
    Unit::update(diff);
-}
-//Prioritize targets
-unsigned int Turret::classifyTarget(Unit* u) {
-   Minion* m = dynamic_cast<Minion*>(u);
-
-   if (m) {
-      switch (m->getType()) {
-         case MINION_TYPE_MELEE:
-            return 4;
-         case MINION_TYPE_CASTER:
-            return 5;
-         case MINION_TYPE_CANNON:
-         case MINION_TYPE_SUPER:
-            return 3;
-      }
-   }
-
-   Champion* c = dynamic_cast<Champion*>(u);
-   if (c) {
-      return 6;
-   }
-
-   //Trap (Shaco box) return 1
-   //Pet (Tibbers) return 2
-
-   return 10;
 }

--- a/gamed/src/Unit.cpp
+++ b/gamed/src/Unit.cpp
@@ -252,3 +252,37 @@ Buff* Unit::getBuff(std::string name){
    }
    return 0;
 }
+
+//Prioritize targets
+unsigned int Unit::classifyTarget(Unit* target) {
+   Turret* t = dynamic_cast<Turret*>(target);
+   
+   // Turrets before champions
+   if (t) {
+      return 6;
+   }
+   
+   Minion* m = dynamic_cast<Minion*>(target);
+
+   if (m) {
+      switch (m->getType()) {
+         case MINION_TYPE_MELEE:
+            return 4;
+         case MINION_TYPE_CASTER:
+            return 5;
+         case MINION_TYPE_CANNON:
+         case MINION_TYPE_SUPER:
+            return 3;
+      }
+   }
+
+   Champion* c = dynamic_cast<Champion*>(target);
+   if (c) {
+      return 7;
+   }
+
+   //Trap (Shaco box) return 1
+   //Pet (Tibbers) return 2
+
+   return 10;
+}


### PR DESCRIPTION
Purple respawns should appear properly now. (Users would respawn and teleport back only after moving)
Added minion target prioritization
Added new packet ID: 0x47
Added buff source
Fixed turret target prioritization (for champions being targeted under tower)
Fixed getMoveSpeed() (how did this compile?)
Fixed SynchVersion indentation
