### PR TITLE
Added gold gain from champion kills (no assits yet)

### DIFF
--- a/gamed/include/Map.h
+++ b/gamed/include/Map.h
@@ -21,9 +21,10 @@ protected:
    uint64 gameTime;
    uint64 nextSpawnTime;
    Game* game;
+   bool firstBlood;
    
 public:
-   Map(Game* game, uint64 firstSpawnTime, uint64 spawnInterval) : game(game), waveNumber(0), firstSpawnTime(firstSpawnTime), spawnInterval(spawnInterval), gameTime(0), nextSpawnTime(firstSpawnTime) { }
+   Map(Game* game, uint64 firstSpawnTime, uint64 spawnInterval) : game(game), waveNumber(0), firstSpawnTime(firstSpawnTime), spawnInterval(spawnInterval), gameTime(0), nextSpawnTime(firstSpawnTime), firstBlood(true) { }
    
    virtual ~Map() { }
    virtual void update(long long diff);
@@ -46,6 +47,8 @@ public:
 
    std::vector<Champion*> getChampionsInRange(Target* t, float range);
    
+   bool getFirstBlood() { return firstBlood; }
+   bool setFirstBlood(bool state) { firstBlood = state; }
 };
 
 #endif

--- a/gamed/include/Unit.h
+++ b/gamed/include/Unit.h
@@ -51,15 +51,18 @@ protected:
    bool targetable;
    bool nextAutoIsCrit;
    LuaScript unitScript = LuaScript(true);
+   
+   int killDeathCounter;
 public:
    Unit(Map* map, uint32 id, std::string model, Stats* stats, uint32 collisionRadius = 40, float x = 0, float y = 0, AI* ai = 0) : Object(map, id, x, y, collisionRadius), stats(stats), ai(ai),
                                                                                  statUpdateTimer(0), model(model), autoAttackDelay(0), autoAttackProjectileSpeed(0), isAttacking(false),
                                                                                  autoAttackCurrentCooldown(0), autoAttackCurrentDelay(0), modelUpdated(false), moveOrder(MOVE_ORDER_MOVE), deathFlag(false),
-                                                                                 unitTarget(0), melee(false), autoAttackFlag(false), nextAutoIsCrit (false) { }
+                                                                                 unitTarget(0), melee(false), autoAttackFlag(false), nextAutoIsCrit (false), killDeathCounter(0) { }
    virtual ~Unit();
    Stats& getStats() { return *stats; }
    virtual void update(int64 diff) override;
    virtual float getMoveSpeed() const { return stats->getMovementSpeed(); }
+   int getKillDeathCounter() { return killDeathCounter; }
    
    std::vector<Buff*> buffs;  
    

--- a/gamed/src/Champion.cpp
+++ b/gamed/src/Champion.cpp
@@ -232,8 +232,49 @@ std::pair<float, float> Champion::getRespawnPosition() {
    return std::make_pair(teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "X"), teamSizeSpawners.get<float>("player" + to_string(spawnNumber) + "Y"));
 }
 void Champion::die(Unit* killer) {
-   respawnTimer = 5000000 + getStats().getLevel()*2500000;
+  respawnTimer = 5000000 + getStats().getLevel()*2500000;
    map->getGame()->notifyChampionDie(this, killer);
+   
+   Champion* cKiller = dynamic_cast<Champion*>(killer);
+   
+	if (!cKiller) {
+      return;
+   }
+   
+   float gold = map->getGoldFor(this);
+   printf("Before: getGoldFromChamp: %f\n Killdc: %i\n Killnc33q4t3246t4 %i\n", gold, cKiller->killDeathCounter,this->killDeathCounter);
+   
+   if(cKiller->killDeathCounter < 0){
+      cKiller->killDeathCounter = 0;
+   }
+   
+   if(cKiller->killDeathCounter >= 0){
+      cKiller->killDeathCounter += 1;
+   }
+   
+   if(this->killDeathCounter > 0){
+      this->killDeathCounter = 0;
+   }
+   
+   if(this->killDeathCounter <= 0){
+      this->killDeathCounter -= 1;
+   }
+    
+    if(!gold) {
+      return;
+    }
+    
+   if(map->getFirstBlood()){
+      gold += 100;
+      map->setFirstBlood(false);
+   }
+   
+	cKiller->getStats().setGold(cKiller->getStats().getGold() + gold);
+	map->getGame()->notifyAddGold(cKiller, this, gold);
+   
+   printf("After: getGoldFromChamp: %f\n Killdc: %i\n Killnc33q4t3246t4 %i\n", gold, cKiller->killDeathCounter,this->killDeathCounter);
+   
+   map->stopTargeting(this);
 }
 int Champion::getTeamSize(){
    LuaScript script(false);

--- a/gamed/src/SummonersRift.cpp
+++ b/gamed/src/SummonersRift.cpp
@@ -165,7 +165,49 @@ const Target SummonersRift::getRespawnLoc(int side) const {
 float SummonersRift::getGoldFor(Unit* u) const {
    Minion* m = dynamic_cast<Minion*>(u);
    
-   if(!m) {
+  if(!m) {
+      Champion* c = dynamic_cast<Champion*>(u);
+      
+      if(!c){
+         return 0.f;
+      }
+      
+      float gold = 300.f; //normal gold for a kill
+      
+      if(c->getKillDeathCounter() < 5 && c->getKillDeathCounter() >= 0){
+         if(c->getKillDeathCounter() == 0){
+            return gold;
+         }
+         
+         for(int i = c->getKillDeathCounter(); i > 1; --i){
+            gold += gold*0.165f;
+         }
+         
+         return gold;
+      }
+      
+      if(c->getKillDeathCounter() >= 5){
+         return 500.f;
+      }
+      
+      if(c->getKillDeathCounter() < 0){
+         float firstDeathGold = gold-gold*0.085f;
+         
+         if(c->getKillDeathCounter() == -1){
+            return firstDeathGold;
+         }
+         
+         for(int i = c->getKillDeathCounter(); i < -1; ++i){
+            firstDeathGold -= firstDeathGold*0.2f;
+         }
+         
+         if(firstDeathGold < 50){
+            firstDeathGold = 50;
+         }
+         
+         return firstDeathGold;
+      }
+      
       return 0.f;
    }
    


### PR DESCRIPTION
Added a basic gold gain for champion kills aswell as a death spree and killing spree tracker.
We still need to implement gold fomr minions and monsters which will reduce the death spree by 1 each 1000 gold gained from them.
Also before 2 minutes into the game there is a reduction of gold on champion kills (not affecting first blood).
