### PR TITLE
Removed minion exp gain when dead

### DIFF
--- a/gamed/include/Map.h
+++ b/gamed/include/Map.h
@@ -56,7 +56,7 @@ public:
    const std::map<uint32, Object*>& getObjects() { return objects; }
    void stopTargeting(Unit* target);
 
-   std::vector<Champion*> getChampionsInRange(Target* t, float range);
+   std::vector<Champion*> getChampionsInRange(Target* t, float range, bool isAlive = false);
    
    bool getFirstBlood() { return firstBlood; }
    void setFirstBlood(bool state) { firstBlood = state; }

--- a/gamed/src/Map.cpp
+++ b/gamed/src/Map.cpp
@@ -187,7 +187,7 @@ void Map::stopTargeting(Unit* target) {
    }
 }
 
-std::vector<Champion*> Map::getChampionsInRange(Target* t, float range) {
+std::vector<Champion*> Map::getChampionsInRange(Target* t, float range, bool isAlive) {
 	std::vector<Champion*> champs;
 	for (auto kv = objects.begin(); kv != objects.end(); ++kv) {
 		Champion* u = dynamic_cast<Champion*>(kv->second);
@@ -197,7 +197,9 @@ std::vector<Champion*> Map::getChampionsInRange(Target* t, float range) {
 		}
 
 		if (t->distanceWith(u)<=range) {
-			champs.push_back(u);
+			if(isAlive && !u->isDead() || !isAlive) {
+				champs.push_back(u);
+			}
 		}
 	}
 	return champs;

--- a/gamed/src/Unit.cpp
+++ b/gamed/src/Unit.cpp
@@ -197,7 +197,7 @@ void Unit::die(Unit* killer) {
    map->getGame()->notifyNpcDie(this, killer);
 
 	float exp = map->getExpFor(this);
-	auto champs = map->getChampionsInRange(this, EXP_RANGE);
+	auto champs = map->getChampionsInRange(this, EXP_RANGE, true);
 	//Cull allied champions
 	champs.erase(std::remove_if(champs.begin(), 
 								champs.end(), 


### PR DESCRIPTION
-Minions shouldn't provide exp to champs when the champ is dead
-Added isAlive bool to getChampionsInRange for future use

We might want to default getChampionsInRange to only return alive champs as you don't want AOE heals healing the dead, or applying a buff that could possibly end up lasting even after their respawn.
