### PR TITLE
Change Client Path via LUA

### DIFF
--- a/gamed/include/VersionCommon.h
+++ b/gamed/include/VersionCommon.h
@@ -1,0 +1,18 @@
+#ifndef __VERSION_COMMON_H__
+#define __VERSION_COMMON_H__
+
+// Split up code by contributor, this allows modules to be disabled if bugs occur.
+
+#define __DRESDENJOHN
+
+// Use #ifdef/#else/#endif clauses to allow for easier debugging.
+
+#ifdef __DRESDENJOHN
+
+	#define __PATH_BY_LUA // Allows end user to set path to client via config.lua
+
+#endif
+
+
+#endif	/* __VERSION_COMMON_H */
+

--- a/gamed/src/main.cpp
+++ b/gamed/src/main.cpp
@@ -24,6 +24,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "Logger.h"
 #include "Pathfinder.h"
 
+#include "VersionCommon.h"
+
+#ifdef __DRESDENJOHN
+	#include "LuaScript.h"
+#endif
+
 #define SERVER_HOST ENET_HOST_ANY 
 #define SERVER_PORT 5119
 #define SERVER_KEY "17BLOhi6KZsTtldTsizvHg=="
@@ -37,7 +43,21 @@ int main(int argc, char ** argv)
 	Logger::instance().setLogFile("../../log.html", false, true);
 	CORE_INFO("Loading RAF files in filearchives/.");
    
-   std::string basePath = RAFManager::getInstance()->findGameBasePath();
+   #ifdef __DRESDENJOHN
+		#ifdef __PATH_BY_LUA
+			LuaScript script(false);
+			script.loadScript("../../lua/config.lua");
+		
+			sol::table pathList = script.getTable("paths");
+			std::string basePath = pathList.get<std::string>("client");
+			std::replace(basePath.begin(), basePath.end(), '\\', '/');
+			CORE_INFO(basePath);
+		#else
+			std::string basePath = RAFManager::getInstance()->findGameBasePath();
+		#endif // __PATH_BY_LUA
+	#else
+		std::string basePath = RAFManager::getInstance()->findGameBasePath();
+	#endif // __DRESDENJOHN
 
    if(!RAFManager::getInstance()->init(basePath + "filearchives")) {
       CORE_ERROR("Couldn't load RAF files. Make sure you have a 'filearchives' directory in the server's root directory. This directory is to be taken from RADS/projects/lol_game_client/");

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,3 +1,12 @@
+paths = {
+--[[
+Path to your 4.20 compatible client folder
+Must point to the lol_game_client folder (and please use TWO \\)
+Example: C:\\LOL420\\RADS\\projects\\lol_game_client\\
+--]]
+	['client'] = "C:\\Users\\John\\Downloads\\LOLPBE\\LOLPBE\\RADS\\projects\\lol_game_client\\"
+}
+
 players = {
 	["player1"] = {
 		["rank"] = "DIAMOND",


### PR DESCRIPTION
Added __PATH_BY_LUA

All further commits by me will include __DRESDENJOHN defines to allow
for debugging

This allows the user to use config.lua in the /lua/ directory to assign
the client location.
